### PR TITLE
fix for cakephp4

### DIFF
--- a/src/Controller/Component/PackComponent.php
+++ b/src/Controller/Component/PackComponent.php
@@ -15,7 +15,7 @@ class PackComponent extends Component
      */
     public function beforeRender(Event $event)
     {
-        $event->subject->helpers += ['Pack.Pack'];
+        $event->getSubject()->viewBuilder()->setHelpers(['Pack']);
     }
 
     /**


### PR DESCRIPTION
- Replaced the following methods:
	- `subject()` (deprecated since cake3.4) -> `getSubject()`
	- `helpers()` (deprecated since cake3.4) -> `setHelpers()`